### PR TITLE
fix: Throw error if graphql response field is null

### DIFF
--- a/src/object-helpers.ts
+++ b/src/object-helpers.ts
@@ -23,7 +23,7 @@ const deepFindPathToProperty = (
     const currentPath = [...path, key];
     const currentValue = object[key];
 
-    if (currentValue.hasOwnProperty(searchProp)) {
+    if (!!currentValue && currentValue.hasOwnProperty(searchProp)) {
       return currentPath;
     }
 


### PR DESCRIPTION
Some times a graphql response fields have value null. This causes currentValue.hasOwnProperty(searchProp) to throw `TypeError: Cannot read properties of null (reading 'hasOwnProperty')` error. The fix checks first if `currentValue` is null before calling hasOwnProperty() method.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #58 

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Throughs TypeError if graphql response field has value of null.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Checks if field is null to prevent TypeError

----
