### PR TITLE
 fix(build): bump tsconfig major version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@octokit/core": "^4.0.0",
         "@octokit/plugin-rest-endpoint-methods": "^7.0.0",
-        "@octokit/tsconfig": "^1.0.2",
+        "@octokit/tsconfig": "^2.0.0",
         "@types/fetch-mock": "^7.3.1",
         "@types/jest": "^29.0.0",
         "@types/node": "^18.0.0",
@@ -1814,9 +1814,9 @@
       }
     },
     "node_modules/@octokit/tsconfig": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
-      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-2.0.0.tgz",
+      "integrity": "sha512-tWnrai3quGt8+gRN2edzo9fmraWekeryXPeXDomMw2oFSpu/lH3VSWGn/q4V+rwjTRMeeXk/ci623/01Zet4VQ==",
       "dev": true
     },
     "node_modules/@octokit/types": {
@@ -8635,9 +8635,9 @@
       }
     },
     "@octokit/tsconfig": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
-      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-2.0.0.tgz",
+      "integrity": "sha512-tWnrai3quGt8+gRN2edzo9fmraWekeryXPeXDomMw2oFSpu/lH3VSWGn/q4V+rwjTRMeeXk/ci623/01Zet4VQ==",
       "dev": true
     },
     "@octokit/types": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@octokit/core": "^4.0.0",
     "@octokit/plugin-rest-endpoint-methods": "^7.0.0",
-    "@octokit/tsconfig": "^1.0.2",
+    "@octokit/tsconfig": "^2.0.0",
     "@types/fetch-mock": "^7.3.1",
     "@types/jest": "^29.0.0",
     "@types/node": "^18.0.0",
@@ -46,6 +46,14 @@
   },
   "jest": {
     "preset": "ts-jest",
+    "transform": {
+      "^.+\\.(ts|tsx)$": [
+        "ts-jest",
+        {
+          "tsconfig": "test/tsconfig.test.json"
+        }
+      ]
+    },
     "coveragePathIgnorePatterns": [
       "./test/testHelpers"
     ],

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,4 @@
-import { CursorValue, PageInfoContext } from "./page-info";
+import type { CursorValue, PageInfoContext } from "./page-info";
 
 // Todo: Add link to explanation
 const generateMessage = (path: string[], cursorValue: CursorValue): string =>

--- a/src/extract-page-info.ts
+++ b/src/extract-page-info.ts
@@ -1,4 +1,4 @@
-import { PageInfoContext } from "./page-info";
+import type { PageInfoContext } from "./page-info";
 import { findPaginatedResourcePath, get } from "./object-helpers";
 
 const extractPageInfos = (responseData: any): PageInfoContext => {

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
This PR uses [auth-token.js#345](https://github.com/octokit/auth-token.js/pull/345) as a model to update the major octokit/tsconfig version and adds a test-specific tsconfig. 