### PR TITLE
fix: add `null` check in `deepFindPathToProperty` function

### DIFF
--- a/src/object-helpers.ts
+++ b/src/object-helpers.ts
@@ -4,11 +4,11 @@ const isObject = (value: any) =>
   Object.prototype.toString.call(value) === "[object Object]";
 
 function findPaginatedResourcePath(responseData: any): string[] {
-  const paginatedResourcePath = deepFindPathToProperty(
+  const paginatedResourcePath: string[] | null = deepFindPathToProperty(
     responseData,
     "pageInfo",
   );
-  if (paginatedResourcePath.length === 0) {
+  if (paginatedResourcePath === null || paginatedResourcePath.length === 0) {
     throw new MissingPageInfo(responseData);
   }
   return paginatedResourcePath;


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #58 

----

### Before the change?
The `deepFindPathToProperty` function would occasionally fail with `TypeError: Cannot read properties of null (reading 'hasOwnProperty')`.


<!-- Please describe the current behavior that you are modifying. -->

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The error has been fixed:
* <a href="diffhunk://#diff-be5e0092082abfc624a87b5ab130c1f22c2c68205637088e88268bbcc776e96dL7-R104">`src/object-helpers.ts`</a>: The `deepFindPathToProperty` function was refactored and its return type updated from `string[]` to `string[] | null`. The refactoring includes the introduction of a new type `TreeNode` and several new helper functions like `getDirectPropertyPath`, `makeTreeNodeChildrenFromData`, and `findPathToObjectContainingProperty`. The `findPaginatedResourcePath` function was also updated to accommodate these changes.
* <a href="diffhunk://#diff-f0e1dffba6fc83b2e2bfe81aeab3e340f2b50b5cbf6aac225bfc5dc2536ea4eaL40-R40">`test/typescript-validate.ts`</a>: The `pageInfoBackwaredExported` function was renamed to `pageInfoBackwardExported` for correct spelling.
* <a href="diffhunk://#diff-85d9d85b851fb0a476af9b2bc59226f08f174e1d5d8a98f1e7c855fee91db97fR1-R73">`test/object-helpers.test.ts`</a>: New tests were added for the `findPaginatedResourcePath` function to validate its behavior in different scenarios. 

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

