### PR TITLE
Change "pull_request" event to "pull_request_target"

### DIFF
--- a/.github/workflows/immediate-response.yml
+++ b/.github/workflows/immediate-response.yml
@@ -6,7 +6,7 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - opened
 jobs:


### PR DESCRIPTION
`pull_request_target` event is more appropriate for the `Issue/PR response` workflow, as the workflow executes against pull requests but in the context of base repository (for security reasons).

Otherwise, when a PR is triggered by the `pull_request` event the `GITHUB_TOKEN` authorization scope may not allow executing API calls in the context of workflows from a pull request based on repository forks.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #139

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

`[respond-to-issue](https://github.com/octokit/plugin-paginate-graphql.js/actions/runs/7148140055/job/19468767085?pr=137#logs)` fails e.g. ≫ https://github.com/octokit/plugin-paginate-graphql.js/actions/runs/7148140055/job/19468767085?pr=137

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The workflow should pass.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

