### PR TITLE
Spelling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,6 @@ Only one version number is bumped at a time, the highest version change trumps t
 Besides publishing a new version to npm, semantic-release also creates a git tag and release
 on GitHub, generates changelogs from the commit messages and puts them into the release notes.
 
-Before the publish it runs the `npm run build` script which creates a `pkg/` folder with distributions for browsers, node and Typescript definitions. The contents of the `pkg/` folder are published to the npm registry.
+Before the publish it runs the `npm run build` script which creates a `pkg/` folder with distributions for browsers, node and TypeScript definitions. The contents of the `pkg/` folder are published to the npm registry.
 
 If the pull request looks good but does not follow the commit conventions, use the <kbd>Squash & merge</kbd> button.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The `paginateGraphql` plugin adds a new `octokit.graphql.paginate()` method whic
 
 The query gets passed over to the `octokit.graphql()`-function. The response is then scanned for the required `pageInfo`-object. If `hasNextPage` is `true`, it will automatically use the `endCursor` to execute the next query until `hasNextPage` is `false`.
 
-While iterating, it ongoingly merges all `nodes` and/or `edges` of all responses and returns a combined response in the end.
+While iterating, it continually merges all `nodes` and/or `edges` of all responses and returns a combined response in the end.
 
 > **Warning**
 > Please note that this plugin only supports pagination of a single resource - so you can **not** execute queries with parallel or nested pagination. You can find more details in [the chapter below](#unsupported-nested-pagination).

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ await octokit.graphql.paginate(
 
 ### Pagination Direction
 
-You can control the pagination direction by the properties deinfed in the `pageInfo` resource.
+You can control the pagination direction by the properties defined in the `pageInfo` resource.
 
 For a forward pagination, use:
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ const { repository } = await octokit.graphql.paginate(
 console.log(`Found ${repository.issues.nodes.length} issues!`);
 ```
 
-There are two convetions this plugin relies on:
+There are two conventions this plugin relies on:
 
 1. The name of the cursor variable must be `$cursor`
 2. You must include a valid `pageInfo` object in the paginated resource (see [Pagination Direction](#pagination-direction) for more info on what is considered valid)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Load `@octokit/plugin-paginate-graphql` and [`@octokit/core`](https://github.com
 ```html
 <script type="module">
   import { Octokit } from "https://esm.sh/@octokit/core";
-  import { paginateGraphql } from "https://esm.sh/@octokit/plugin-paginate-graphql";
+  import { paginateGraphQL } from "https://esm.sh/@octokit/plugin-paginate-graphql";
 </script>
 ```
 
@@ -31,7 +31,7 @@ Install with `npm install @octokit/core @octokit/plugin-paginate-graphql`. Optio
 
 ```js
 const { Octokit } = require("@octokit/core");
-const { paginateGraphql } = require("@octokit/plugin-paginate-graphql");
+const { paginateGraphQL } = require("@octokit/plugin-paginate-graphql");
 ```
 
 </td></tr>
@@ -39,7 +39,7 @@ const { paginateGraphql } = require("@octokit/plugin-paginate-graphql");
 </table>
 
 ```js
-const MyOctokit = Octokit.plugin(paginateGraphql);
+const MyOctokit = Octokit.plugin(paginateGraphQL);
 const octokit = new MyOctokit({ auth: "secret123" });
 
 const { repository } = await octokit.graphql.paginate(
@@ -68,7 +68,7 @@ There are two conventions this plugin relies on:
 
 ## `octokit.graphql.paginate()`
 
-The `paginateGraphql` plugin adds a new `octokit.graphql.paginate()` method which accepts a query with a single `$cursor` variable that is used to paginate.
+The `paginateGraphQL` plugin adds a new `octokit.graphql.paginate()` method which accepts a query with a single `$cursor` variable that is used to paginate.
 
 The query gets passed over to the `octokit.graphql()`-function. The response is then scanned for the required `pageInfo`-object. If `hasNextPage` is `true`, it will automatically use the `endCursor` to execute the next query until `hasNextPage` is `false`.
 
@@ -183,7 +183,7 @@ If you provide all 4 properties in a `pageInfo`, the plugin will default to forw
 
 ### Unsupported: Nested pagination
 
-Nested pagination with GraphlQL is complicated, so the following **is not supported**:
+Nested pagination with GraphQL is complicated, so the following **is not supported**:
 
 ```js
 await octokit.graphql.paginate((cursor) => {
@@ -218,7 +218,7 @@ There is a great video from GitHub Universe 2019 [Advanced patterns for GitHub's
 
 ### TypeScript Support
 
-You can type the response of the `paginateGraphql()` and `iterator()` functions like this:
+You can type the response of the `paginateGraphQL()` and `iterator()` functions like this:
 
 ```ts
 await octokit.graphql.paginate<RepositoryIssueResponseType>((cursor) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { createIterator } from "./iterator";
 import { createPaginate } from "./paginate";
 export type { PageInfoForward, PageInfoBackward } from "./page-info";
 
-export function paginateGraphql(octokit: Octokit) {
+export function paginateGraphQL(octokit: Octokit) {
   octokit.graphql;
   return {
     graphql: Object.assign(octokit.graphql, {

--- a/test/paginate-graphql.e2e.ts
+++ b/test/paginate-graphql.e2e.ts
@@ -1,7 +1,7 @@
 import { Octokit } from "@octokit/core";
-import { paginateGraphql } from "../src";
+import { paginateGraphQL } from "../src";
 
-const PatchedOctokit = Octokit.plugin(paginateGraphql);
+const PatchedOctokit = Octokit.plugin(paginateGraphQL);
 
 const token = process.env.E2E_GITHUB_TOKEN;
 if (!token) {

--- a/test/paginate.test.ts
+++ b/test/paginate.test.ts
@@ -106,7 +106,7 @@ describe("pagination", () => {
       `
       query paginate($cursor: String, $organization: String!) {
         repository(owner: $organization, name: "rest.js") {
-          issues(first: 10, after: $curosr) {
+          issues(first: 10, after: $cursor) {
             nodes {
               title
             }

--- a/test/testHelpers/mock-octokit.ts
+++ b/test/testHelpers/mock-octokit.ts
@@ -1,8 +1,8 @@
 import { Octokit } from "@octokit/core";
-import { paginateGraphql } from "../../src/index";
+import { paginateGraphQL } from "../../src/index";
 import fetchMock from "fetch-mock";
 
-const PatchedOctokit = Octokit.plugin(paginateGraphql);
+const PatchedOctokit = Octokit.plugin(paginateGraphQL);
 
 const MockOctokit = ({ responses = [{}] }: { responses?: any[] } = {}) => {
   let calledQueries: string[] = [];

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -3,10 +3,10 @@
 // ************************************************************
 
 import { Octokit } from "@octokit/core";
-import { paginateGraphql, PageInfoBackward, PageInfoForward } from "../src";
+import { paginateGraphQL, PageInfoBackward, PageInfoForward } from "../src";
 import { TestResponseType } from "./testHelpers/mock-response";
 
-const MyOctokit = Octokit.plugin(paginateGraphql);
+const MyOctokit = Octokit.plugin(paginateGraphQL);
 const octokit = new MyOctokit();
 
 const query = `

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -37,7 +37,7 @@ export async function typedIterator() {
   }
 }
 
-export function pageInfoBackwaredExported(): PageInfoBackward {
+export function pageInfoBackwardExported(): PageInfoBackward {
   return {
     hasPreviousPage: true,
     startCursor: "startCursor",


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->


----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* typos https://github.com/jsoref/plugin-paginate-graphql.js/actions/runs/7950796206#summary-21703502067

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* https://github.com/jsoref/plugin-paginate-graphql.js/actions/runs/7950796358

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

```diff
-const { paginateGraphql } = require("@octokit/plugin-paginate-graphql");
+const { paginateGraphQL } = require("@octokit/plugin-paginate-graphql");
```

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [x] Yes
- [ ] No

----

I'm happy to drop that one change. There were enough typos in the neighborhood that I'd like to make the argument that it's better to properly spell GraphQL than to inconsistently spell it including with typos.