### PR TITLE
fix: use type imports for `@octokit/core`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Octokit } from "@octokit/core";
+import type { Octokit } from "@octokit/core";
 import { createIterator } from "./iterator";
 import { createPaginate } from "./paginate";
 export type { PageInfoForward, PageInfoBackward } from "./page-info";

--- a/src/iterator.ts
+++ b/src/iterator.ts
@@ -1,5 +1,5 @@
 import { extractPageInfos } from "./extract-page-info";
-import { Octokit } from "@octokit/core";
+import type { Octokit } from "@octokit/core";
 import { getCursorFrom, hasAnotherPage } from "./page-info";
 import { MissingCursorChange } from "./errors";
 

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -1,4 +1,4 @@
-import { Octokit } from "@octokit/core";
+import type { Octokit } from "@octokit/core";
 import { mergeResponses } from "./merge-responses";
 import { createIterator } from "./iterator";
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The imports for `@octokit/core` were being outputted in the build files even if they weren't used at runtime

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The imports for `@octokit/core` are no longer present in the build files

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

