### PR TITLE
fix: actually output only ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "build": "node scripts/build.mjs && tsc -p tsconfig.json",
     "lint": "prettier --check '{src,test}/**/*' README.md package.json",
     "lint:fix": "prettier --write '{src,test}/**/*' README.md package.json",
-    "pretest": "npm run -s lint",
+    "pretest": "npm run -s lint && npm run build",
     "test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest --coverage",
-    "test:typescript": "npx tsc --noEmit --declaration --noUnusedLocals --esModuleInterop --strict test/typescript-validate.ts",
+    "test:typescript": "npx tsc --noEmit --declaration --noUnusedLocals --esModuleInterop --strict --module node16 --moduleResolution node16 test/typescript-validate.ts",
     "test:watch": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest --watch",
     "test:e2e": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest --testRegex test/*.e2e.ts"
   },
@@ -59,7 +59,8 @@
       ]
     },
     "coveragePathIgnorePatterns": [
-      "./test/testHelpers"
+      "./test/testHelpers",
+      "./pkg"
     ],
     "coverageThreshold": {
       "global": {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -8,6 +8,9 @@ const sharedOptions = {
   minify: false,
   allowOverwrite: true,
   packages: "external",
+  platform: "neutral",
+  format: "esm",
+  target: "es2022",
 };
 
 async function main() {
@@ -18,8 +21,6 @@ async function main() {
     entryPoints: await glob(["./src/*.ts", "./src/**/*.ts"]),
     outdir: "pkg/dist-src",
     bundle: false,
-    platform: "neutral",
-    format: "esm",
     ...sharedOptions,
     sourcemap: false,
   });
@@ -35,27 +36,12 @@ async function main() {
 
   const entryPoints = ["./pkg/dist-src/index.js"];
 
-  await Promise.all([
-    // Build the a CJS Node.js bundle
-    esbuild.build({
-      entryPoints,
-      outdir: "pkg/dist-node",
-      bundle: true,
-      platform: "node",
-      target: "node18",
-      format: "cjs",
-      ...sharedOptions,
-    }),
-    // Build an ESM browser bundle
-    esbuild.build({
-      entryPoints,
-      outdir: "pkg/dist-web",
-      bundle: true,
-      platform: "browser",
-      format: "esm",
-      ...sharedOptions,
-    }),
-  ]);
+ await esbuild.build({
+    entryPoints,
+    outdir: "pkg/dist-bundle",
+    bundle: true,
+    ...sharedOptions,
+  });
 
   // Copy the README, LICENSE to the pkg folder
   await copyFile("LICENSE", "pkg/LICENSE");
@@ -74,12 +60,12 @@ async function main() {
       {
         ...pkg,
         files: ["dist-*/**", "bin/**"],
-        main: "dist-node/index.js",
+        main: "dist-bundle/index.js",
         types: "dist-types/index.d.ts",
         exports: {
           ".": {
             types: "./dist-types/index.d.ts",
-            import: "./dist-node/index.js",
+            import: "./dist-bundle/index.js",
           }
         },
         sideEffects: false,

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,0 +1,7 @@
+import { paginateGraphQL } from "../pkg/dist-bundle/index.js";
+
+describe("Test package exports", () => {
+  it("should export the paginateGraphQL function", () => {
+    expect(paginateGraphQL).toBeInstanceOf(Function);
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #177

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Outputted CJS even though the package is marked as being ESM

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Output a single ES2022 ESM bundle

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

