### PR TITLE
fix(types): export `paginateGraphQLInterface`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import { createPaginate } from "./paginate.js";
 export type { PageInfoForward, PageInfoBackward } from "./page-info.js";
 export { VERSION } from "./version.js";
 
+// Export the paginateGraphQLInterface type in order to fix TypeScript errors in downstream projects
+// The inferred type of 'Octokit' cannot be named without a reference to '@octokit/core/node_modules/@octokit/graphql/types'. This is likely not portable. A type annotation is necessary.
 export type paginateGraphQLInterface = {
   graphql: Octokit["graphql"] & {
     paginate: ReturnType<typeof createPaginate> & {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { createPaginate } from "./paginate.js";
 export type { PageInfoForward, PageInfoBackward } from "./page-info.js";
 export { VERSION } from "./version.js";
 
-type paginateGraphQLInterface = {
+export type paginateGraphQLInterface = {
   graphql: Octokit["graphql"] & {
     paginate: ReturnType<typeof createPaginate> & {
       iterator: ReturnType<typeof createIterator>;


### PR DESCRIPTION
This resolves issues in consumers of this package getting errors from TypeScript

```
The inferred type of 'Octokit' cannot be named without a reference to '@octokit/core/node_modules/@octokit/graphql/types'. This is likely not portable. A type annotation is necessary.
```

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

