### PR TITLE
fix: `TypeError with hasOwnProperty` in `deepFindPathToProperty`

### DIFF
--- a/src/object-helpers.ts
+++ b/src/object-helpers.ts
@@ -1,6 +1,8 @@
 import { MissingPageInfo } from "./errors.js";
 
-const isObject = (value: any) =>
+type unknownObject = Record<string | number | symbol, unknown>;
+
+const isObject = (value: unknown): value is unknownObject =>
   Object.prototype.toString.call(value) === "[object Object]";
 
 function findPaginatedResourcePath(responseData: any): string[] {
@@ -15,7 +17,7 @@ function findPaginatedResourcePath(responseData: any): string[] {
 }
 
 const deepFindPathToProperty = (
-  object: any,
+  object: unknownObject,
   searchProp: string,
   path: string[] = [],
 ): string[] => {
@@ -23,11 +25,11 @@ const deepFindPathToProperty = (
     const currentPath = [...path, key];
     const currentValue = object[key];
 
-    if (currentValue.hasOwnProperty(searchProp)) {
-      return currentPath;
-    }
-
     if (isObject(currentValue)) {
+      if (currentValue.hasOwnProperty(searchProp)) {
+        return currentPath;
+      }
+
       const result = deepFindPathToProperty(
         currentValue,
         searchProp,

--- a/src/object-helpers.ts
+++ b/src/object-helpers.ts
@@ -4,11 +4,11 @@ const isObject = (value: any) =>
   Object.prototype.toString.call(value) === "[object Object]";
 
 function findPaginatedResourcePath(responseData: any): string[] {
-  const paginatedResourcePath: string[] | null = deepFindPathToProperty(
+  const paginatedResourcePath = deepFindPathToProperty(
     responseData,
     "pageInfo",
   );
-  if (paginatedResourcePath === null || paginatedResourcePath.length === 0) {
+  if (paginatedResourcePath.length === 0) {
     throw new MissingPageInfo(responseData);
   }
   return paginatedResourcePath;

--- a/test/extract-page-infos.test.ts
+++ b/test/extract-page-infos.test.ts
@@ -1,3 +1,4 @@
+import { MissingPageInfo } from "../src/errors.js";
 import { extractPageInfos } from "../src/extract-page-info.js";
 import type { PageInfoContext } from "../src/page-info.js";
 
@@ -62,5 +63,11 @@ describe("extractPageInfos()", (): void => {
       pageInfo: { hasNextPage: false, endCursor: null },
       pathInQuery: ["data", "repository", "issues"],
     });
+  });
+
+  it("throws a MissingPageInfo error if the response has unexpected structure", async (): Promise<void> => {
+    expect(() => extractPageInfos({ unknown1: null, unknown2: 42 })).toThrow(
+      MissingPageInfo,
+    );
   });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #58 with fix to handle non object values
Resolves https://github.com/octokit/plugin-paginate-graphql.js/pull/59#issuecomment-1664592782 with adding unit test

Background is written in https://github.com/octokit/plugin-paginate-graphql.js/pull/137#discussion_r1772558051

This change still returns errors for caller, but replaced to correct errors such as `MissingPageInfo` instead of `TypeError`.
@stergion @nickfloyd How do you think this direction?

----

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No - As far as I don't expect braking change in this PR, if you find, please tell me

----

