### PR TITLE
feat: explain unsupported pageInfo arrays

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -24,13 +24,16 @@ class MissingCursorChange extends Error {
 class MissingPageInfo extends Error {
   override name = "MissingPageInfo";
 
-  constructor(readonly response: any) {
+  constructor(
+    readonly response: any,
+    pageInfoInsideArray = false,
+  ) {
     super(
-      `No pageInfo property found in response. Please make sure to specify the pageInfo in your query. Response-Data: ${JSON.stringify(
-        response,
-        null,
-        2,
-      )}`,
+      `No pageInfo property found in response. Please make sure to specify the pageInfo in your query.${
+        pageInfoInsideArray
+          ? " A pageInfo property was found inside an array, which is not supported. If you are querying a single node, use `node` instead of `nodes` so the paginated resource is not wrapped in an array."
+          : ""
+      } Response-Data: ${JSON.stringify(response, null, 2)}`,
     );
 
     if (Error.captureStackTrace) {

--- a/src/object-helpers.ts
+++ b/src/object-helpers.ts
@@ -11,10 +11,35 @@ function findPaginatedResourcePath(responseData: any): string[] {
     "pageInfo",
   );
   if (paginatedResourcePath.length === 0) {
-    throw new MissingPageInfo(responseData);
+    throw new MissingPageInfo(
+      responseData,
+      hasPropertyInsideArray(responseData, "pageInfo"),
+    );
   }
   return paginatedResourcePath;
 }
+
+const hasPropertyInsideArray = (
+  value: unknown,
+  searchProp: string,
+  insideArray = false,
+): boolean => {
+  if (Array.isArray(value)) {
+    return value.some((item) => hasPropertyInsideArray(item, searchProp, true));
+  }
+
+  if (!isObject(value)) {
+    return false;
+  }
+
+  if (insideArray && Object.prototype.hasOwnProperty.call(value, searchProp)) {
+    return true;
+  }
+
+  return Object.values(value).some((item) =>
+    hasPropertyInsideArray(item, searchProp, insideArray),
+  );
+};
 
 const deepFindPathToProperty = (
   object: unknownObject,

--- a/test/extract-page-infos.test.ts
+++ b/test/extract-page-infos.test.ts
@@ -71,4 +71,21 @@ describe("extractPageInfos()", (): void => {
       MissingPageInfo,
     );
   });
+
+  it("explains that pageInfo inside an array is not supported", () => {
+    const queryResult = {
+      nodes: [
+        {
+          timelineItems: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [],
+          },
+        },
+      ],
+    };
+
+    expect(() => extractPageInfos(queryResult)).toThrow(
+      "A pageInfo property was found inside an array, which is not supported. If you are querying a single node, use `node` instead of `nodes`",
+    );
+  });
 });


### PR DESCRIPTION
Resolves #238

----

### Before the change?

* When a response contained `pageInfo` below an array, the plugin reported that no `pageInfo` property existed, even though the response printed one.

### After the change?

* Detect `pageInfo` nested below an array and explain that this shape is unsupported.
* Recommend using `node` instead of `nodes` for single-node queries so the paginated resource is not wrapped in an array.
* Preserve the existing error type and message for responses that genuinely have no `pageInfo`.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----

### Verification

* `npx prettier --check src/errors.ts src/object-helpers.ts test/extract-page-infos.test.ts`
* `node scripts/build.mjs && npx tsc -p tsconfig.json --types node`
* 22 unit tests pass with coverage.
* The two live E2E assertions currently expect the upstream repository to have 3 topics, but GitHub now returns 4; this is unrelated to the changed error path.